### PR TITLE
Remove clousers from routes

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -1,0 +1,13 @@
+<?php
+namespace App\Http\Controllers;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+
+class UserController extends Controller
+{
+    public function __invoke(Request $request)
+    {
+        return $request->user();
+    }
+}

--- a/app/Http/Controllers/WelcomeController.php
+++ b/app/Http/Controllers/WelcomeController.php
@@ -1,0 +1,13 @@
+<?php
+namespace App\Http\Controllers;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+
+class WelcomeController extends Controller
+{
+    public function __invoke(Request $request)
+    {
+        return view('welcome');
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -13,13 +13,11 @@ use Illuminate\Http\Request;
 |
 */
 
-Route::get('/notes', 'NoteController@getAllNotes')->middleware(\App\Http\Middleware\Cors::class);
-Route::get('/note/0', 'NoteController@getLatestUpdatedNote')->middleware(\App\Http\Middleware\Cors::class);
-Route::get('/note/{id}', 'NoteController@getNote')->middleware(\App\Http\Middleware\Cors::class);
-Route::post('/note/create', 'NoteController@createNote')->middleware(\App\Http\Middleware\Cors::class);
-Route::post('/note/update/{id}', 'NoteController@updateNote')->middleware(\App\Http\Middleware\Cors::class);
-Route::post('/note/delete/{id}', 'NoteController@deleteNote')->middleware(\App\Http\Middleware\Cors::class);
+Route::get('/notes', 'NoteController@getAllNotes')->middleware('cors');
+Route::get('/note/0', 'NoteController@getLatestUpdatedNote')->middleware('cors');
+Route::get('/note/{id}', 'NoteController@getNote')->middleware('cors');
+Route::post('/note/create', 'NoteController@createNote')->middleware('cors');
+Route::post('/note/update/{id}', 'NoteController@updateNote')->middleware('cors');
+Route::post('/note/delete/{id}', 'NoteController@deleteNote')->middleware('cors');
 
-Route::middleware('auth:api')->get('/user', function (Request $request) {
-    return $request->user();
-});
+Route::get('/user', 'UserController')->middleware('auth:api');

--- a/routes/web.php
+++ b/routes/web.php
@@ -11,6 +11,4 @@
 |
 */
 
-Route::get('/', function () {
-    return view('welcome');
-});
+Route::get('/', 'WelcomeController');


### PR DESCRIPTION
Remove clousers as unable to run `php artisan route:cache` as it cannot prepare the route. Added basic controllers